### PR TITLE
debootstrap: Improve package compression support

### DIFF
--- a/functions
+++ b/functions
@@ -799,20 +799,35 @@ extract_dpkg_deb_data () {
 extract_ar_deb_field () {
 	local pkg="$1"
 	local field="$2"
+	local tarball=$(ar -t "$pkg" | grep "^control\.tar")
 
-	ar -p "$pkg" control.tar.gz | zcat |
-	    tar -O -xf - control ./control 2>/dev/null |
-	    grep -i "^$field:" | sed -e 's/[^:]*: *//' | head -n 1
+	case "$tarball" in
+		control.tar.gz) cat_cmd=zcat ;;
+		control.tar.xz) cat_cmd=xzcat ;;
+		control.tar.zst) cat_cmd=zstdcat ;;
+		*) error 1 UNKNOWNCONTROLCOMP "Unknown compression type for %s in %s" "$tarball" "$pkg" ;;
+	esac
+
+
+	if in_path $cat_cmd; then
+		ar -p "$pkg" "$tarball" | $cat_cmd |
+			tar -O -xf - control ./control 2>/dev/null |
+			grep -i "^$field:" | sed -e 's/[^:]*: *//' | head -n 1
+	else
+		error 1 UNPACKCMDUNVL "Extracting %s requires the %s command, which is not available" "$pkg" "$cat_cmd"
+	fi
+
 }
 
 extract_ar_deb_data () {
 	local pkg="$1"
-	local tarball=$(ar -t "$pkg" | grep "^data.tar.[bgx]z")
+	local tarball=$(ar -t "$pkg" | grep "^data.tar")
 
 	case "$tarball" in
 		data.tar.gz) cat_cmd=zcat ;;
 		data.tar.bz2) cat_cmd=bzcat ;;
 		data.tar.xz) cat_cmd=xzcat ;;
+		data.tar.zst) cat_cmd=zstdcat ;;
 		*) error 1 UNKNOWNDATACOMP "Unknown compression type for %s in %s" "$tarball" "$pkg" ;;
 	esac
 


### PR DESCRIPTION
[debootstrap] Improve package compression support. Fixes JB#54483

Add xz and zstd compression handling for deb control.tar, and zstd for data.tar, to support newer OS versions.